### PR TITLE
Bugfix prepare_sector_network.py

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -973,7 +973,7 @@ def add_methanol_to_power(n, costs, types=None):
             p_nom_extendable=True,
             capital_cost=capital_cost,
             overnight_cost=costs.at["CCGT", "investment"]
-            *costs.at["CCGT", "efficiency"],
+            * costs.at["CCGT", "efficiency"],
             marginal_cost=costs.at["CCGT", "VOM"],
             efficiency=costs.at["CCGT", "efficiency"],
             efficiency2=costs.at["methanolisation", "carbondioxide-input"],


### PR DESCRIPTION
wrongfully set comma leads to an error in `prepare_sector_network` when `config[sector][methanol][methanol_to_power][ccgt]` is activated

Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
