### PR TITLE
fix: Handle empty valid_grouping_years case in add_heating_capacities_installed_before_baseyear function

### DIFF
--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -870,13 +870,15 @@ def add_heating_capacities_installed_before_baseyear(
             )
 
             assert valid_grouping_years.is_monotonic_increasing
-
-            # get number of years of each interval
-            _years = valid_grouping_years.diff()
-            # Fill NA from .diff() with value for the first interval
-            _years[0] = valid_grouping_years[0] - baseyear + default_lifetime
-            # Installation is assumed to be linear for the past
-            ratios = _years / _years.sum()
+            if len(valid_grouping_years) == 0:
+                ratios = pd.Series([])
+            else:
+                # get number of years of each interval
+                _years = valid_grouping_years.diff()
+                # Fill NA from .diff() with value for the first interval
+                _years[0] = valid_grouping_years[0] - baseyear + default_lifetime
+                # Installation is assumed to be linear for the past
+                ratios = _years / _years.sum()
 
         for ratio, grouping_year in zip(ratios, valid_grouping_years):
             # Add heat pumps


### PR DESCRIPTION
## Issue
I did not modify the configuration and ran the simulation using  `snakemake -call all --configfile=config/config.public.yaml`. The following error was encountered:
<img width="998" alt="image" src="https://github.com/user-attachments/assets/6ce04f95-1442-4ab0-8003-99b8fbf4f6c0" />

If the target year is 2040, `valid_grouping_years` is an empty array, which will cause an error in the `valid_grouping_years[0]`.

## Solution

If `valid_grouping_years` is empty, set `ratios` to empty directly.


Before asking for a review for this PR make sure to complete the following checklist:

- [x] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [x] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
