### PR TITLE
fix: change unit assignment to return a list of unique values in ariadne_subplot

### DIFF
--- a/scripts/pypsa-de/plot_ariadne_variables.py
+++ b/scripts/pypsa-de/plot_ariadne_variables.py
@@ -543,7 +543,7 @@ def ariadne_subplot(
 
     # Check that all values have the same Unit
     if not unit:
-        unit = df.columns.get_level_values("Unit").unique().dropna().item()
+        unit = df.columns.get_level_values("Unit").unique().dropna().tolist()
 
     df.columns = df.columns.droplevel("Unit")
 


### PR DESCRIPTION
## Issue
I did not modify the configuration and ran the simulation using  `snakemake ariadne_all --configfile=config/config.public.yaml`. The following error was encountered:
<img width="1186" alt="image" src="https://github.com/user-attachments/assets/c4c1b965-7235-4722-bbb7-14cc496a026e" />

The result of running the `units_index.unique().dropna()` is `Index(['PJ/yr', 'TWh/yr'], dtype='object', name='Unit')`, and it does not support the `item()` method.

## Solution

Use `tolist()` instead of `item()`.


## Checklist
Before asking for a review for this PR make sure to complete the following checklist:

- [x] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [x] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
