### PR TITLE
Drop CHP plants with expired lifetime

### DIFF
--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -43,6 +43,7 @@ from build_powerplants import add_custom_powerplants
 
 from build_powerplants import add_custom_powerplants
 
+
 def add_build_year_to_new_assets(n: pypsa.Network, baseyear: int) -> None:
     """
     Add build year to new assets in the network.
@@ -260,7 +261,7 @@ def add_power_capacities_installed_before_baseyear(
 
     # add chp plants
     add_chp_plants(n, grouping_years, costs, baseyear)
-    
+
     # drop assets which are already phased out / decommissioned
     phased_out = df_agg[df_agg["DateOut"] < baseyear].index
     df_agg.drop(phased_out, inplace=True)
@@ -511,10 +512,10 @@ def add_chp_plants(n, grouping_years, costs, baseyear):
     # phase out date at the end of the year)
     chp.Fueltype = chp.Fueltype.map(rename_fuel)
 
-    chp["grouping_year"] = np.take(
-        grouping_years, np.digitize(chp.DateIn, grouping_years, right=True)
+    chp["lifetime"] = (chp.DateOut - chp["grouping_year"] + 1).fillna(
+        snakemake.params.costs["fill_values"]["lifetime"]
     )
-    chp["lifetime"] = chp.DateOut - chp["grouping_year"] + 1
+    chp = chp.loc[chp.grouping_year + chp.lifetime >= baseyear]
 
     # check if the CHPs were read in from MaStR for Germany
     if "Capacity_thermal" in chp.columns:
@@ -737,7 +738,8 @@ def add_chp_plants(n, grouping_years, costs, baseyear):
                     bus3="co2 atmosphere",
                     carrier=f"urban central {generator} CHP",
                     p_nom=p_nom[bus] / costs.at[key, "efficiency"],
-                    capital_cost=costs.at[key, "capital_cost"] * costs.at[key, "efficiency"],
+                    capital_cost=costs.at[key, "capital_cost"]
+                    * costs.at[key, "efficiency"],
                     overnight_cost=costs.at[key, "investment"]
                     * costs.at[key, "efficiency"],
                     marginal_cost=costs.at[key, "VOM"],
@@ -758,7 +760,8 @@ def add_chp_plants(n, grouping_years, costs, baseyear):
                     bus2=bus + " urban central heat",
                     carrier=generator,
                     p_nom=p_nom[bus] / costs.at[key, "efficiency"],
-                    capital_cost=costs.at[key, "capital_cost"] * costs.at[key, "efficiency"],
+                    capital_cost=costs.at[key, "capital_cost"]
+                    * costs.at[key, "efficiency"],
                     overnight_cost=costs.at[key, "investment"]
                     * costs.at[key, "efficiency"],
                     marginal_cost=costs.at[key, "VOM"],
@@ -1052,7 +1055,9 @@ def add_heating_capacities_installed_before_baseyear(
                 overnight_cost=costs.at["biomass boiler", "efficiency"]
                 * costs.at["biomass boiler", "investment"],
                 p_nom=(
-                    existing_capacities.loc[nodes, (heat_system.value, "biomass boiler")]
+                    existing_capacities.loc[
+                        nodes, (heat_system.value, "biomass boiler")
+                    ]
                     * ratio
                     / costs.at["biomass boiler", "efficiency"]
                 ),


### PR DESCRIPTION
As some CHP plants retrieved from the MaStR lack a specified decommissioning date, a default lifetime of 25 years (set in `config.default.yaml`) is assumed in `add_existing_baseyear`. Once all plants have an assigned lifetime, those that have exceeded their lifetime are filtered out.


Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
