### PR TITLE
Add ci test config

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -291,7 +291,10 @@ sector:
       2040: 0.6
       2045: 0.8
       2050: 1.0
-  central_heat_vent: true
+  heat_vent:
+    urban central: true
+    urban decentral: true
+    rural: true
   co2_spatial: true
   biomass_spatial: true
   #TBD what to include in config

--- a/config/test/config.dach.yaml
+++ b/config/test/config.dach.yaml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Contributors to PyPSA-DE <https://github.com/pypsa/pypsa-eur>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+run:
+  prefix: "test-sector-myopic-dach"
+  name:
+  - KN2045_Bal_v4
+
+scenario:
+  clusters:
+  - 5 #current options: 27, 49
+countries: ['DE', 'AT', 'CH']
+
+snapshots:
+  start: "2013-03-01"
+  end: "2013-03-08"
+
+atlite:
+  default_cutout: dach-03-2013-sarah3-era5
+  cutouts:
+    dach-03-2013-sarah3-era5:
+      module: [sarah, era5] # in priority order
+      x: [5., 18.]
+      y: [45., 56.]
+      time: ["2013-03-01", "2013-03-08"]
+
+renewable:
+  onwind:
+    cutout: dach-03-2013-sarah3-era5
+  offwind-ac:
+    cutout: dach-03-2013-sarah3-era5
+    max_depth: false
+  offwind-dc:
+    cutout: dach-03-2013-sarah3-era5
+    max_depth: false
+  offwind-float:
+    cutout: dach-03-2013-sarah3-era5
+    max_depth: false
+    min_depth: false
+  solar:
+    cutout: dach-03-2013-sarah3-era5
+  solar-hsat:
+    cutout: dach-03-2013-sarah3-era5
+
+clustering:
+  focus_weights: []
+  temporal:
+    resolution_sector: 3H
+
+electricity:
+  renewable_carriers: [solar, solar-hsat, onwind, offwind-ac, offwind-dc] # removed hydro, offwind-float

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -665,7 +665,7 @@ def add_chp_plants(n, grouping_years, costs, baseyear):
 
     # CHPs that are not from MaStR
 
-    if options["central_heat_vent"]:
+    if options["heat_vent"]["urban central"]:
         uch_buses = n.buses.index[n.buses.carrier == "urban central heat"]
         missing_uch_buses = pd.Series(
             {

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2661,7 +2661,6 @@ def add_heat(
             unit="MWh_th",
         )
 
-        # if heat_system == HeatSystem.URBAN_CENTRAL and options["central_heat_vent"]:
         if options["heat_vent"][heat_system.system_type.value]:
             n.add(
                 "Generator",

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3256,6 +3256,14 @@ def add_biomass(
 
     biomass_potentials = pd.read_csv(biomass_potentials_file, index_col=0)
 
+    nhours = n.snapshot_weightings.generators.sum()
+    if nhours < 8760:
+        logger.warning(
+            "The length of the optimization horizon is less than 1 year."
+            "Assuming biomass potentails are equally distributed over the year."
+        )
+        biomass_potentials *= nhours / 8760
+
     # need to aggregate potentials if gas not nodally resolved
     if (
         options["gas_network"]

--- a/scripts/pypsa-de/additional_functionality.py
+++ b/scripts/pypsa-de/additional_functionality.py
@@ -290,7 +290,10 @@ def h2_production_limits(n, investment_year, limits_volume_min, limits_volume_ma
 
 def electricity_import_limits(n, investment_year, limits_volume_max):
     for ct in limits_volume_max["electricity_import"]:
-        limit = limits_volume_max["electricity_import"][ct][investment_year] * 1e6
+        limit = limits_volume_max["electricity_import"][ct][investment_year] * 1e6 
+
+        if limit < 0:
+            limit *= n.snapshot_weightings.generators.sum() / 8760
 
         logger.info(f"limiting electricity imports in {ct} to {limit / 1e6} TWh/a")
 

--- a/scripts/pypsa-de/modify_prenetwork.py
+++ b/scripts/pypsa-de/modify_prenetwork.py
@@ -839,8 +839,12 @@ def aladin_mobility_demand(n):
     # get aladin data
     aladin_demand = pd.read_csv(snakemake.input.aladin_demand, index_col=0)
 
+    simulation_period_correction_factor = (
+        n.snapshot_weightings.objective.sum() / 8760
+    ) 
+
     # oil demand
-    oil_demand = aladin_demand.Liquids
+    oil_demand = aladin_demand.Liquids * simulation_period_correction_factor
     oil_index = n.loads[
         (n.loads.carrier == "land transport oil") & (n.loads.index.str[:2] == "DE")
     ].index
@@ -853,7 +857,7 @@ def aladin_mobility_demand(n):
     )
 
     # hydrogen demand
-    h2_demand = aladin_demand.Hydrogen
+    h2_demand = aladin_demand.Hydrogen * simulation_period_correction_factor
     h2_index = n.loads[
         (n.loads.carrier == "land transport fuel cell")
         & (n.loads.index.str[:2] == "DE")
@@ -867,7 +871,7 @@ def aladin_mobility_demand(n):
     )
 
     # electricity demand
-    ev_demand = aladin_demand.Electricity
+    ev_demand = aladin_demand.Electricity * simulation_period_correction_factor
     ev_index = n.loads[
         (n.loads.carrier == "land transport EV") & (n.loads.index.str[:2] == "DE")
     ].index


### PR DESCRIPTION
@lkstrp works locally for me now, we should make sure that the download of the cutout from zenodo works automatically

This PR contains some fixes that are required for running in subannual resolution. I did not check the results for consistency so this does not guarantee that the subannual results make sense, but at least the fixes avoid some infeasibilities

Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
