### PR TITLE
Expanding Myopic Optimization to 2050

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20250403-chp_eop_conversion
+  prefix: 20250404-fit_for_2050
   name:
   # - CurrentPolicies
   - KN2045_Bal_v4
@@ -71,6 +71,7 @@ scenario:
   - 2035
   - 2040
   - 2045
+  - 2050
 
 existing_capacities:
   grouping_years_power: [1920, 1950, 1955, 1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020]
@@ -363,6 +364,7 @@ industry:
     2035: 0.3
     2040: 0.6
     2045: 1
+    2050: 1
 #HVC primary/recycling based on values used in Neumann et al https://doi.org/10.1016/j.joule.2023.06.016, linearly interpolated between 2020 and 2050
 #2020 recycling rates based on Agora https://static.agora-energiewende.de/fileadmin/Projekte/2021/2021_02_EU_CEAP/A-EW_254_Mobilising-circular-economy_study_WEB.pdf
 #fractions refer to the total primary HVC production in 2020
@@ -444,6 +446,7 @@ solving:
             2035: 160 # EEG2023 Ziel für 2040
             2040: 250
             2045: 250
+            2045: 250
         offwind:
           DE:
             2020: 7.8
@@ -452,6 +455,7 @@ solving:
             2035: 50 # Planned projects until 2035 (offshore_connection_points.csv) -1.3 GW for potential delays
             2040: 65   # Planned projects until 2040 -1.5 GW for potential retirments
             2045: 70
+            2050: 70
         solar:
           DE:
             2020: 53.7
@@ -460,6 +464,7 @@ solving:
             2035: 400
             2040: 800
             2045: 1000
+            2050: 1000
       Store:
         co2 sequestered:
           DE:
@@ -469,6 +474,7 @@ solving:
             2035: 20000
             2040: 50000
             2045: 80000
+            2050: 80000
       Link:
         methanolisation:
           DE:
@@ -476,12 +482,14 @@ solving:
             2035: 5.7
             2040: 5.7
             2045: 5.7
+            2050: 5.7
         Fischer-Tropsch:
           DE:
             2030: 2.5
             2035: 2.5
             2040: 2.5
             2045: 2.5
+            2050: 2.5
         HVC to air:
           DE:
             2020: 0 # all HVC in Germany is either burned or recycled
@@ -490,6 +498,7 @@ solving:
             2035: 0
             2040: 0
             2045: 0
+            2050: 0
     limits_capacity_min:
       Generator:
         onwind:
@@ -509,10 +518,6 @@ solving:
               # EEG2023; Ziel for 2024: 88 GW and for 2026: 128 GW,
               # assuming at least 1/3 of difference reached in 2025
             2025: 101
-            2030: 101
-            2035: 101
-            2040: 101
-            2045: 101
   # For reference, this are the values specified in the laws
   # limits_capacity_min:
   #     Generator:
@@ -550,6 +555,7 @@ solving:
           2035: 40
           2040: 80
           2045: 125
+          2050: 125
       electrolysis:
       # boundary condition lower?
         DE:
@@ -559,6 +565,7 @@ solving:
           2035: 130
           2040: 215
           2045: 300
+          2050: 300
       h2_derivate_import:
       # boundary condition lower?
         DE:
@@ -568,6 +575,7 @@ solving:
           2035: 105
           2040: 200
           2045: 300
+          2050: 300
       h2_import:
       # boundary condition lower?
         DE:
@@ -577,6 +585,7 @@ solving:
           2035: 115
           2040: 220
           2045: 325
+          2050: 325
     limits_volume_min:
       electrolysis:
         DE:
@@ -586,6 +595,7 @@ solving:
           2035: 0
           2040: 0
           2045: 0
+          2050: 0
     limits_power_max: # in GW
       DE:
         2020: 15
@@ -594,6 +604,7 @@ solving:
         2035: 25
         2040: 30
         2045: 35
+        2050: 35
   # solver:
   #   options: gurobi-numeric-focus
   # solver_options:

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -34,21 +34,13 @@ CurrentPolicies:
           onwind:
             DE:
               2030: 86.5   # 75 % Wind-an-Land Law
-              2035: 86.5
-              2040: 86.5
-              2045: 86.5
           offwind:
             DE:
               2030: 17.3
               2035: 29.3
-              2040: 29.3
-              2045: 29.3
           solar:
             DE:
               2030: 161.25   # 75 % PV strategy
-              2035: 161.25
-              2040: 161.25
-              2045: 161.25
       # boundary condition of maximum volumes
       limits_capacity_max:
         Generator:
@@ -64,52 +56,6 @@ CurrentPolicies:
           solar:
             DE:
               2030: 215 # uba Projektionsbericht
-      limits_volume_max:
-        # constrain electricity import in TWh
-        electricity_import:
-          DE:
-            2020: -20
-            2025: 0
-            2030: 0
-            2035: 40
-            2040: 80
-            2045: 125
-        electrolysis:
-        # boundary condition lower?
-          DE:
-            2020: 0
-            2025: 5
-            2030: 45
-            2035: 130
-            2040: 215
-            2045: 300
-        h2_derivate_import:
-        # boundary condition lower?
-          DE:
-            2020: 0
-            2025: 0
-            2030: 10
-            2035: 105
-            2040: 200
-            2045: 300
-        h2_import:
-        # boundary condition lower?
-          DE:
-            2020: 0
-            2025: 5
-            2030: 15
-            2035: 115
-            2040: 220
-            2045: 325
-      limits_volume_min:
-        electrolysis:
-          DE:
-            2020: 0
-            2025: 0
-            2030: 0
-            2035: 0
-            2040: 0
-            2045: 0
 
   industry:
     steam_biomass_fraction: 0.4
@@ -144,50 +90,6 @@ KN2045_Bal_v4:
     transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
   solving:
     constraints:
-      # boundary condition of maximum volumes
-      limits_volume_max:
-        # constrain electricity import in TWh
-        electricity_import:
-          DE:
-            2020: -20
-            2025: 0
-            2030: 0
-            2035: 40
-            2040: 80
-            2045: 125
-        electrolysis:
-          DE:
-            2020: 0
-            2025: 5
-            2030: 45
-            2035: 130
-            2040: 215
-            2045: 300
-        h2_derivate_import:
-          DE:
-            2020: 0
-            2025: 0
-            2030: 10
-            2035: 105
-            2040: 200
-            2045: 300
-        h2_import:
-          DE:
-            2020: 0
-            2025: 5
-            2030: 15
-            2035: 115
-            2040: 220
-            2045: 325
-      limits_volume_min:
-        electrolysis:
-          DE:
-            2020: 0
-            2025: 0
-            2030: 0
-            2035: 0
-            2040: 0
-            2045: 0
       limits_capacity_min:
         Link:
           H2 Electrolysis:
@@ -226,6 +128,7 @@ KN2045_Elec_v4:
             2035: 50
             2040: 100
             2045: 150
+            2050: 150
         electrolysis:
           DE:
             2020: 0
@@ -234,6 +137,7 @@ KN2045_Elec_v4:
             2035: 95
             2040: 145
             2045: 200
+            2050: 200
         h2_derivate_import:
           DE:
             2020: 0
@@ -242,6 +146,7 @@ KN2045_Elec_v4:
             2035: 70
             2040: 130
             2045: 200
+            2050: 200
         h2_import:
           DE:
             2020: 0
@@ -250,15 +155,7 @@ KN2045_Elec_v4:
             2035: 90
             2040: 170
             2045: 250
-      limits_volume_min:
-        electrolysis:
-          DE:
-            2020: 0
-            2025: 0
-            2030: 0
-            2035: 0
-            2040: 0
-            2045: 0
+            2050: 250
       limits_capacity_min:
         Link:
           H2 Electrolysis:
@@ -297,6 +194,7 @@ KN2045_H2_v4:
             2035: 30
             2040: 70
             2045: 100 # scenario guidelines
+            2050: 100
 
         # constrain hydrogen import in TWh
         h2_import:
@@ -307,6 +205,7 @@ KN2045_H2_v4:
             2035: 155
             2040: 265
             2045: 400 # scenario guidelines
+            2050: 400
         # import of h2 derivatives in TWh
         h2_derivate_import:
           DE:
@@ -316,6 +215,7 @@ KN2045_H2_v4:
             2035: 140
             2040: 270
             2045: 400 # scenario guidelines
+            2050: 400
         electrolysis:
           DE:
             2020: 0
@@ -324,6 +224,7 @@ KN2045_H2_v4:
             2035: 160
             2040: 275
             2045: 400 # scenario guidelines
+            2050: 400
 
       limits_volume_min:
         electrolysis:
@@ -333,6 +234,7 @@ KN2045_H2_v4:
             2035: 0
             2040: 0
             2045: 200
+            2050: 200
       limits_capacity_min:
         Link:
           H2 Electrolysis:
@@ -363,31 +265,6 @@ KN2045plus_EasyRide:
     constraints:
       # boundary condition of maximum volumes
       limits_volume_max: # following the Bal scenario
-        # constrain electricity import in TWh
-        electricity_import:
-          DE:
-            2020: -20
-            2025: 0
-            2030: 0
-            2035: 40
-            2040: 80
-            2045: 125
-        electrolysis:
-          DE:
-            2020: 0
-            2025: 5
-            2030: 45
-            2035: 130
-            2040: 215
-            2045: 300
-        h2_derivate_import:
-          DE:
-            2020: 0
-            2025: 0
-            2030: 10
-            2035: 105
-            2040: 200
-            2045: 300
         h2_import:
           DE:
             2020: 0
@@ -396,15 +273,7 @@ KN2045plus_EasyRide:
             2035: 115
             2040: 220
             2045: 325
-      limits_volume_min:
-        electrolysis:
-          DE:
-            2020: 0
-            2025: 0
-            2030: 0
-            2035: 0
-            2040: 0
-            2045: 0
+            2050: 325
       limits_capacity_min:
         Link:
           H2 Electrolysis:
@@ -423,6 +292,7 @@ KN2045plus_EasyRide:
       2035: 0.25
       2040: 0.34
       2045: 0.43
+      2050: 0.43
 
 KN2045plus_LowDemand:
 # Im Vergleich zu Easy Ride eher knappe EE Erzeugung
@@ -449,6 +319,7 @@ KN2045plus_LowDemand:
             2035: 20
             2040: 40
             2045: 62.5
+            2050: 62.5
         electrolysis:
           DE:
             2020: 0
@@ -457,6 +328,7 @@ KN2045plus_LowDemand:
             2035: 65
             2040: 107.5
             2045: 150
+            2050: 150
         h2_derivate_import:
           DE:
             2020: 0
@@ -465,6 +337,7 @@ KN2045plus_LowDemand:
             2035: 52.5
             2040: 100
             2045: 150
+            2050: 150
         h2_import:
           DE:
             2020: 0
@@ -473,15 +346,7 @@ KN2045plus_LowDemand:
             2035: 57.5
             2040: 110
             2045: 162.5
-      limits_volume_min:
-        electrolysis:
-          DE:
-            2020: 0
-            2025: 0
-            2030: 0
-            2035: 0
-            2040: 0
-            2045: 0
+            2050: 162.5
       limits_capacity_min:
         Link:
           H2 Electrolysis:
@@ -500,6 +365,7 @@ KN2045plus_LowDemand:
       2035: 0.25
       2040: 0.34
       2045: 0.43
+      2050: 0.43
 
 KN2045minus_WorstCase:
 # Nachfrage nach Endenergie ist höher als in den Szenarien 1-3
@@ -539,6 +405,7 @@ KN2045minus_WorstCase:
             2035: 20
             2040: 40
             2045: 62.5
+            2050: 62.5
         electrolysis:
           DE:
             2020: 0
@@ -547,6 +414,7 @@ KN2045minus_WorstCase:
             2035: 65
             2040: 107.5
             2045: 150
+            2050: 150
         h2_derivate_import:
           DE:
             2020: 0
@@ -555,6 +423,7 @@ KN2045minus_WorstCase:
             2035: 52.5
             2040: 100
             2045: 150
+            2050: 150
         h2_import:
           DE:
             2020: 0
@@ -563,35 +432,19 @@ KN2045minus_WorstCase:
             2035: 57.5
             2040: 110
             2045: 162.5
-      limits_volume_min:
-        electrolysis:
-          DE:
-            2020: 0
-            2025: 0
-            2030: 0
-            2035: 0
-            2040: 0
-            2045: 0
+            2050: 162.5
       limits_capacity_min:
         Generator:
           onwind:
             DE:
               2030: 86.5   # 75 % Wind-an-Land Law
-              2035: 86.5
-              2040: 86.5
-              2045: 86.5
           offwind:
             DE:
               2030: 17.3   # 75 % Wind-auf-See Law
               2035: 29.3
-              2040: 29.3
-              2045: 29.3
           solar:
             DE:
               2030: 161.25   # 75 % PV strategy
-              2035: 161.25
-              2040: 161.25
-              2045: 161.25
         Link:
           H2 Electrolysis:
             DE:
@@ -625,6 +478,7 @@ KN2045minus_WorstCase:
       2035: 0.18
       2040: 0.24
       2045: 0.29
+      2050: 0.29
   offshore_nep_force:
     cutin_year: 2025
     cutout_year: 2035 # Hackily reduced to 2030 if delay_years: 1
@@ -656,31 +510,6 @@ KN2045minus_SupplyFocus:
     constraints:
       # boundary condition of maximum volumes
       limits_volume_max: # following the Bal scenario
-        # constrain electricity import in TWh
-        electricity_import:
-          DE:
-            2020: -20
-            2025: 0
-            2030: 0
-            2035: 40
-            2040: 80
-            2045: 125
-        electrolysis:
-          DE:
-            2020: 0
-            2025: 5
-            2030: 45
-            2035: 130
-            2040: 215
-            2045: 300
-        h2_derivate_import:
-          DE:
-            2020: 0
-            2025: 0
-            2030: 10
-            2035: 105
-            2040: 200
-            2045: 300
         h2_import:
           DE:
             2020: 0
@@ -689,30 +518,16 @@ KN2045minus_SupplyFocus:
             2035: 115
             2040: 220
             2045: 325
-      limits_volume_min:
-        electrolysis:
-          DE:
-            2020: 0
-            2025: 0
-            2030: 0
-            2035: 0
-            2040: 0
-            2045: 0
+            2050: 325
       limits_capacity_min:
         Generator:
           onwind:
             DE:
               2030: 115 # Wind-an-Land Law
-              2035: 115 # not forcing more EE
-              2040: 115
-              2045: 115
           solar:
             DE:
               2025: 101
               2030: 215 # PV strategy
-              2035: 215 # not forcing more EE
-              2040: 215
-              2045: 215
         Link:
           H2 Electrolysis:
             DE:
@@ -734,6 +549,7 @@ KN2045minus_SupplyFocus:
       2035: 0.18
       2040: 0.24
       2045: 0.29
+      2050: 0.29
 
 KN2045_Bal_LowDemand:
 # Ausgewogener Mix an Technologien zur Dekarbonisierung der Sektoren
@@ -755,31 +571,6 @@ KN2045_Bal_LowDemand:
     constraints:
       # boundary condition of maximum volumes
       limits_volume_max:
-        # constrain electricity import in TWh
-        electricity_import:
-          DE:
-            2020: -20
-            2025: 0
-            2030: 0
-            2035: 40
-            2040: 80
-            2045: 125
-        electrolysis:
-          DE:
-            2020: 0
-            2025: 5
-            2030: 45
-            2035: 130
-            2040: 215
-            2045: 300
-        h2_derivate_import:
-          DE:
-            2020: 0
-            2025: 0
-            2030: 10
-            2035: 105
-            2040: 200
-            2045: 300
         h2_import:
           DE:
             2020: 0
@@ -788,15 +579,7 @@ KN2045_Bal_LowDemand:
             2035: 115
             2040: 220
             2045: 325
-      limits_volume_min:
-        electrolysis:
-          DE:
-            2020: 0
-            2025: 0
-            2030: 0
-            2035: 0
-            2040: 0
-            2045: 0
+            2050: 325
       limits_capacity_min:
         Link:
           H2 Electrolysis:
@@ -815,6 +598,7 @@ KN2045_Bal_LowDemand:
       2035: 0.25
       2040: 0.34
       2045: 0.43
+      2050: 0.43
 
 KN2045_Bal_HighDemand:
 # Ausgewogener Mix an Technologien zur Dekarbonisierung der Sektoren
@@ -836,31 +620,6 @@ KN2045_Bal_HighDemand:
     constraints:
       # boundary condition of maximum volumes
       limits_volume_max:
-        # constrain electricity import in TWh
-        electricity_import:
-          DE:
-            2020: -20
-            2025: 0
-            2030: 0
-            2035: 40
-            2040: 80
-            2045: 125
-        electrolysis:
-          DE:
-            2020: 0
-            2025: 5
-            2030: 45
-            2035: 130
-            2040: 215
-            2045: 300
-        h2_derivate_import:
-          DE:
-            2020: 0
-            2025: 0
-            2030: 10
-            2035: 105
-            2040: 200
-            2045: 300
         h2_import:
           DE:
             2020: 0
@@ -869,15 +628,7 @@ KN2045_Bal_HighDemand:
             2035: 115
             2040: 220
             2045: 325
-      limits_volume_min:
-        electrolysis:
-          DE:
-            2020: 0
-            2025: 0
-            2030: 0
-            2035: 0
-            2040: 0
-            2045: 0
+            2050: 325
       limits_capacity_min:
         Link:
           H2 Electrolysis:
@@ -896,3 +647,4 @@ KN2045_Bal_HighDemand:
       2035: 0.18
       2040: 0.24
       2045: 0.29
+      2050: 0.29

--- a/scripts/pypsa-de/build_scenarios.py
+++ b/scripts/pypsa-de/build_scenarios.py
@@ -159,7 +159,8 @@ def write_to_scenario_yaml(input, output, scenarios, df):
             2035,
             2040,
             2045,
-        ]  # for 2050 we still need data
+            2050,
+        ]
 
         aviation_demand_factor = get_transport_growth(
             df.loc[snakemake.params.leitmodelle["transport"], reference_scenario, :],

--- a/scripts/pypsa-de/modify_cost_data.py
+++ b/scripts/pypsa-de/modify_cost_data.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         new_year = matched_year
     elif snakemake.params.cost_horizon == "pessimist":
         logger.info(f"Pessimistic cost scenario for {matched_year}.")
-        new_year = matched_year + 5
+        new_year = min(matched_year + 5, 2050)
     elif snakemake.params.cost_horizon == "optimist":
         logger.info(f"Optimistic cost scenario for {matched_year}.")
         new_year = matched_year - 5


### PR DESCRIPTION
Closes https://github.com/PyPSA/pypsa-de/issues/63

This PR
- cleans up the constraints (e.g. minimum capacity limits don't need to be repeated when staying constant)
- removes double appearance of constraints between `config.yaml` and `scenarios.manual.yaml`
- tweaks the rule `build_scenarios` to include 2050
- tweaks `modify_cost_data` for a pessimist cost horizon since the cost data for 2055 does not exist (fall back to 2050)

Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
