### PR TITLE
Move final prenetworks to the resources folder

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -359,8 +359,7 @@ rule modify_prenetwork:
         regions_offshore=resources("regions_offshore_base_s_{clusters}.geojson"),
         offshore_connection_points="ariadne-data/offshore_connection_points.csv",
     output:
-        network=RESULTS
-        + "networks/base_s_{clusters}_{opts}_{sector_opts}_{planning_horizons}_final.nc",
+        network=resources("networks/base_s_{clusters}_{opts}_{sector_opts}_{planning_horizons}_final.nc"),
     resources:
         mem_mb=4000,
     log:

--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -119,8 +119,7 @@ rule solve_sector_network_myopic:
         custom_extra_functionality=input_custom_extra_functionality,
         energy_year=config_provider("energy", "energy_totals_year"),
     input:
-        network=RESULTS
-        + "networks/base_s_{clusters}_{opts}_{sector_opts}_{planning_horizons}_final.nc",
+        network=resources("networks/base_s_{clusters}_{opts}_{sector_opts}_{planning_horizons}_final.nc"),
         co2_totals_name=resources("co2_totals.csv"),
         energy_totals=resources("energy_totals.csv"),
     output:


### PR DESCRIPTION
Moving final prenetworks to the resources folder.

Before asking for a review for this PR make sure to complete the following checklist:

- [x] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
_not applicable_
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
_not applicable_
- [ ] A brief description of the changes has been added to `Changelog.md`
_not applicable_
- [x] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
_not applicable_
