### PR TITLE
Simplify scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+- Simplified scenarion definition and made `Mix` the default scenario
 - 0.3: workflow is all public now, no longer requires credentials to internal data
 - Allowing myopic optimization until 2050
 - CHP plants located in onshore regions without district heating are represented as EOP plants

--- a/Snakefile
+++ b/Snakefile
@@ -272,7 +272,7 @@ rule retrieve_ariadne_database:
     output:
         data=resources("ariadne_database.csv"),
     log:
-        "logs/pypsa-de/retrieve_ariadne_database.log",
+        logs("retrieve_ariadne_database.log"),
     resources:
         mem_mb=1000,
     script:
@@ -570,7 +570,7 @@ rule download_ariadne_template:
             keep_local=True,
         ),
     output:
-        resources("template_ariadne_database.xlsx"),
+        "data/template_ariadne_database.xlsx",
     run:
         move(input[0], output[0])
 
@@ -589,7 +589,7 @@ rule export_ariadne_variables:
         NEP_year=config_provider("costs", "NEP"),
         NEP_transmission=config_provider("costs", "transmission"),
     input:
-        template=resources("template_ariadne_database.xlsx"),
+        template="data/template_ariadne_database.xlsx",
         industry_demands=expand(
             resources(
                 "industrial_energy_demand_base_s_{clusters}_{planning_horizons}.csv"

--- a/Snakefile
+++ b/Snakefile
@@ -266,13 +266,13 @@ rule retrieve_egon_data:
 
 rule retrieve_ariadne_database:
     params:
-        db_name=config_provider("iiasa_database", "db_name"),
-        leitmodelle=config_provider("iiasa_database", "leitmodelle"),
-        scenarios=config_provider("iiasa_database", "scenarios"),
+        db_name=config["iiasa_database"]["db_name"],
+        leitmodelle=config["iiasa_database"]["leitmodelle"],
+        scenarios=config["iiasa_database"]["scenarios"],
     output:
-        data=resources("ariadne_database.csv"),
+        data="resources/ariadne_database.csv",
     log:
-        logs("retrieve_ariadne_database.log"),
+        "logs/retrieve_ariadne_database.log",
     resources:
         mem_mb=1000,
     script:
@@ -315,7 +315,7 @@ rule build_mobility_demand:
         planning_horizons=config_provider("scenario", "planning_horizons"),
         leitmodelle=config_provider("iiasa_database", "leitmodelle"),
     input:
-        ariadne=resources("ariadne_database.csv"),
+        ariadne="resources/ariadne_database.csv",
         clustered_pop_layout=resources("pop_layout_base_s_{clusters}.csv"),
     output:
         mobility_demand=resources(
@@ -453,7 +453,7 @@ rule modify_existing_heating:
         iiasa_reference_scenario=config_provider("iiasa_database", "reference_scenario"),
         leitmodelle=config_provider("iiasa_database", "leitmodelle"),
     input:
-        ariadne=resources("ariadne_database.csv"),
+        ariadne="resources/ariadne_database.csv",
         existing_heating="data/existing_infrastructure/existing_heating_raw.csv",
     output:
         existing_heating=resources("existing_heating.csv"),
@@ -501,7 +501,7 @@ rule modify_industry_demand:
     params:
         reference_scenario=config_provider("iiasa_database", "reference_scenario"),
     input:
-        ariadne=resources("ariadne_database.csv"),
+        ariadne="resources/ariadne_database.csv",
         industrial_production_per_country_tomorrow=resources(
             "industrial_production_per_country_tomorrow_{planning_horizons}.csv"
         ),
@@ -639,7 +639,7 @@ rule plot_ariadne_variables:
         reference_scenario=config_provider("iiasa_database", "reference_scenario"),
     input:
         exported_variables_full=RESULTS + "ariadne/exported_variables_full.xlsx",
-        ariadne_database=resources("ariadne_database.csv"),
+        ariadne_database="resources/ariadne_database.csv",
     output:
         primary_energy=RESULTS + "ariadne/primary_energy.png",
         primary_energy_detailed=RESULTS + "ariadne/primary_energy_detailed.png",
@@ -703,10 +703,10 @@ rule ariadne_all:
 
 rule build_scenarios:
     params:
-        scenarios=config_provider("run", "name"),
-        leitmodelle=config_provider("iiasa_database", "leitmodelle"),
+        scenarios=config["run"]["name"],
+        leitmodelle=config["iiasa_database"]["leitmodelle"],
     input:
-        ariadne_database=resources("ariadne_database.csv"),
+        ariadne_database="resources/ariadne_database.csv",
         scenario_yaml=config["run"]["scenarios"]["manual_file"],
     output:
         scenario_yaml=config["run"]["scenarios"]["file"],

--- a/Snakefile
+++ b/Snakefile
@@ -311,7 +311,6 @@ if config["enable"]["retrieve"] and config["enable"].get("retrieve_cost_data", T
 
 rule build_mobility_demand:
     params:
-        db_name=config_provider("iiasa_database", "db_name"),
         reference_scenario=config_provider("iiasa_database", "reference_scenario"),
         planning_horizons=config_provider("scenario", "planning_horizons"),
         leitmodelle=config_provider("iiasa_database", "leitmodelle"),
@@ -500,7 +499,6 @@ rule build_existing_chp_de:
 
 rule modify_industry_demand:
     params:
-        db_name=config_provider("iiasa_database", "db_name"),
         reference_scenario=config_provider("iiasa_database", "reference_scenario"),
     input:
         ariadne=resources("ariadne_database.csv"),
@@ -706,7 +704,6 @@ rule ariadne_all:
 rule build_scenarios:
     params:
         scenarios=config_provider("run", "name"),
-        db_name=config_provider("iiasa_database", "db_name"),
         leitmodelle=config_provider("iiasa_database", "leitmodelle"),
     input:
         ariadne_database=resources("ariadne_database.csv"),

--- a/config/config.de.yaml
+++ b/config/config.de.yaml
@@ -434,6 +434,16 @@ solving:
         H2 pipeline retrofitted: 0.05
       fractional_last_unit_size: true
   constraints:
+    # The default CO2 budget uses the KSG targets, and the non CO2 emissions from the REMIND model in the KN2045_Mix scenario
+    co2_budget_national:
+      DE:
+        2020: 0.671
+        2025: 0.523
+        2030: 0.346
+        2035: 0.216
+        2040: 0.09
+        2045: -0.05
+        2050: -0.048
     efuel_export_ban: false
     limits_capacity_max:
       Generator:

--- a/config/config.de.yaml
+++ b/config/config.de.yaml
@@ -269,6 +269,9 @@ first_technology_occurrence:
 
 costs:
   horizon: "mean" # "optimist", "pessimist" or "mean"
+  NEP: 2023
+  transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
+
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#sector
 sector:
@@ -342,6 +345,9 @@ sector:
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#industry
 industry:
   ammonia: false
+  steam_biomass_fraction: 0.4
+  steam_hydrogen_fraction: 0.3
+  steam_electricity_fraction: 0.3
   St_primary_fraction:
     2020: 0.6
     2025: 0.55
@@ -511,6 +517,10 @@ solving:
               # EEG2023; Ziel for 2024: 88 GW and for 2026: 128 GW,
               # assuming at least 1/3 of difference reached in 2025
             2025: 101
+        Link:
+          H2 Electrolysis:
+            DE:
+              2030: 5
   # For reference, this are the values specified in the laws
   # limits_capacity_min:
   #     Generator:

--- a/config/config.de.yaml
+++ b/config/config.de.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20250425_public_db
+  prefix: 20250507_simple_scenarios
   name:
   # - ExPol
   - KN2045_Mix

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -72,13 +72,12 @@ ExPol:
 
 
 KN2045_Mix:
-# Default scenario
+# Default scenario, defined in pypsa.de.yaml
 # Ausgewogener Mix an Technologien zur Dekarbonisierung der Sektoren
 # Breites Energieträgerportfolio in der Endenergie (Strom, Wasserstoff, synthetische Kraftstoffe)
 # Ausbau der erneuerbare Stromerzeugung erreicht politisch gesetzte Ziele
 # Importe erneuerbar erzeugter Energien auf mittlerem Niveau
 # dient als Referenzszenario in der Familie der Ariadne-Szenarien
-  co2_budget_DE_source: KSG
 
 
 KN2045_Elek:

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -23,8 +23,6 @@ ExPol:
     2050: 0.419
 
   costs:
-    horizon: "mean"
-    NEP: 2023
     transmission: "underground" # either overhead line ("overhead") or underground cable ("underground")
   solving:
     constraints:
@@ -56,10 +54,6 @@ ExPol:
             DE:
               2030: 215 # uba Projektionsbericht
 
-  industry:
-    steam_biomass_fraction: 0.4
-    steam_hydrogen_fraction: 0.3
-    steam_electricity_fraction: 0.3
 
   sector:
     district_heating:
@@ -88,12 +82,7 @@ KN2045_Elek:
 
   iiasa_database:
     reference_scenario: KN2045_Elek
-  co2_budget_DE_source: KSG
 
-  costs:
-    horizon: "mean"
-    NEP: 2023
-    transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
   solving:
     constraints:
       limits_volume_max:
@@ -134,11 +123,6 @@ KN2045_Elek:
             2040: 170
             2045: 250
             2050: 250
-      limits_capacity_min:
-        Link:
-          H2 Electrolysis:
-            DE:
-              2030: 5
 
   industry:
     steam_biomass_fraction: 0.4
@@ -153,12 +137,7 @@ KN2045_H2:
 
   iiasa_database:
     reference_scenario: KN2045_H2
-  co2_budget_DE_source: KSG
 
-  costs:
-    horizon: "mean"
-    NEP: 2023
-    transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
   solving:
     constraints:
       limits_volume_max:
@@ -212,11 +191,6 @@ KN2045_H2:
             2040: 0
             2045: 200
             2050: 200
-      limits_capacity_min:
-        Link:
-          H2 Electrolysis:
-            DE:
-              2030: 5
 
   industry:
     steam_biomass_fraction: 0.4
@@ -232,34 +206,6 @@ KN2045_NFniedrig:
 
   iiasa_database:
     reference_scenario: KN2045plus_LowDemand
-  co2_budget_DE_source: KSG
-
-  costs:
-    horizon: "mean"
-    NEP: 2023
-    transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
-  solving:
-    constraints:
-      # boundary condition of maximum volumes
-      limits_volume_max:
-        h2_import:
-          DE:
-            2020: 0
-            2025: 5
-            2030: 15
-            2035: 115
-            2040: 220
-            2045: 325
-            2050: 325
-      limits_capacity_min:
-        Link:
-          H2 Electrolysis:
-            DE:
-              2030: 5
-  industry:
-    steam_biomass_fraction: 0.4
-    steam_hydrogen_fraction: 0.3
-    steam_electricity_fraction: 0.3
 
   sector:
     reduce_space_heat_exogenously_factor:
@@ -280,34 +226,6 @@ KN2045_NFhoch:
 
   iiasa_database:
     reference_scenario: KN2045minus_SupplyFocus
-  co2_budget_DE_source: KSG
-
-  costs:
-    horizon: "mean"
-    NEP: 2023
-    transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
-  solving:
-    constraints:
-      # boundary condition of maximum volumes
-      limits_volume_max:
-        h2_import:
-          DE:
-            2020: 0
-            2025: 5
-            2030: 15
-            2035: 115
-            2040: 220
-            2045: 325
-            2050: 325
-      limits_capacity_min:
-        Link:
-          H2 Electrolysis:
-            DE:
-              2030: 5
-  industry:
-    steam_biomass_fraction: 0.4
-    steam_hydrogen_fraction: 0.3
-    steam_electricity_fraction: 0.3
 
   sector:
     reduce_space_heat_exogenously_factor:

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -72,32 +72,14 @@ ExPol:
 
 
 KN2045_Mix:
+# Default scenario
 # Ausgewogener Mix an Technologien zur Dekarbonisierung der Sektoren
 # Breites Energieträgerportfolio in der Endenergie (Strom, Wasserstoff, synthetische Kraftstoffe)
 # Ausbau der erneuerbare Stromerzeugung erreicht politisch gesetzte Ziele
 # Importe erneuerbar erzeugter Energien auf mittlerem Niveau
 # dient als Referenzszenario in der Familie der Ariadne-Szenarien
-
-  iiasa_database:
-    reference_scenario: KN2045_Mix
   co2_budget_DE_source: KSG
 
-  costs:
-    horizon: "mean"
-    NEP: 2023
-    transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
-  solving:
-    constraints:
-      limits_capacity_min:
-        Link:
-          H2 Electrolysis:
-            DE:
-              2030: 5
-
-  industry:
-    steam_biomass_fraction: 0.4
-    steam_hydrogen_fraction: 0.3
-    steam_electricity_fraction: 0.3
 
 KN2045_Elek:
 # Fokus auf dem Hochlauf von Technologien zur direkten Elektrifizierung der Sektoren

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -205,7 +205,7 @@ KN2045_NFniedrig:
 # dient als Referenzszenario in der Familie der Ariadne-Szenarien
 
   iiasa_database:
-    reference_scenario: KN2045plus_LowDemand
+    reference_scenario: KN2045_NFniedrig
 
   sector:
     reduce_space_heat_exogenously_factor:
@@ -225,7 +225,7 @@ KN2045_NFhoch:
 # dient als Referenzszenario in der Familie der Ariadne-Szenarien
 
   iiasa_database:
-    reference_scenario: KN2045minus_SupplyFocus
+    reference_scenario: KN2045_NFhoch
 
   sector:
     reduce_space_heat_exogenously_factor:

--- a/scripts/pypsa-de/additional_functionality.py
+++ b/scripts/pypsa-de/additional_functionality.py
@@ -354,7 +354,7 @@ def electricity_import_limits(n, investment_year, limits_volume_max):
         )
 
 
-def add_co2limit_country(n, limit_countries, snakemake):
+def add_national_co2_budgets(n, snakemake, national_co2_budgets, investment_year):
     """
     Add a set of emissions limit constraints for specified countries.
 
@@ -363,11 +363,12 @@ def add_co2limit_country(n, limit_countries, snakemake):
     Parameters
     ----------
     n : pypsa.Network
-    limit_countries : dict
-    snakemake: snakemake object
-    """
-    logger.info("Adding CO2 budget limit for each country as per unit of 1990 levels")
+    snakemake : snakemake.io.Snakemake
+    national_co2_budgets : dict
+    investment_year : int
 
+    """
+    logger.info("Adding national CO2 budgets")
     nhours = n.snapshot_weightings.generators.sum()
     nyears = nhours / 8760
 
@@ -378,10 +379,10 @@ def add_co2limit_country(n, limit_countries, snakemake):
 
     co2_total_totals = co2_totals[sectors].sum(axis=1) * nyears
 
-    for ct in limit_countries:
-        limit = co2_total_totals[ct] * limit_countries[ct]
+    for ct in national_co2_budgets:
+        limit = co2_total_totals[ct] * national_co2_budgets[ct][investment_year]
         logger.info(
-            f"Limiting emissions in country {ct} to {limit_countries[ct]:.1%} of "
+            f"Limiting emissions in country {ct} to {national_co2_budgets[ct][investment_year]:.1%} of "
             f"1990 levels, i.e. {limit:,.2f} tCO2/a",
         )
 
@@ -418,10 +419,10 @@ def add_co2limit_country(n, limit_countries, snakemake):
         # Aviation demand
         energy_totals = pd.read_csv(snakemake.input.energy_totals, index_col=[0, 1])
         domestic_aviation = energy_totals.loc[
-            ("DE", snakemake.params.energy_year), "total domestic aviation"
+            (ct, snakemake.params.energy_year), "total domestic aviation"
         ]
         international_aviation = energy_totals.loc[
-            ("DE", snakemake.params.energy_year), "total international aviation"
+            (ct, snakemake.params.energy_year), "total international aviation"
         ]
         domestic_factor = domestic_aviation / (
             domestic_aviation + international_aviation
@@ -440,8 +441,8 @@ def add_co2limit_country(n, limit_countries, snakemake):
         )
 
         # Adding Efuel imports and exports to constraint
-        incoming_oil = n.links.index[n.links.index == "EU renewable oil -> DE oil"]
-        outgoing_oil = n.links.index[n.links.index == "DE renewable oil -> EU oil"]
+        incoming_oil = n.links.index[n.links.index == f"EU renewable oil -> {ct} oil"]
+        outgoing_oil = n.links.index[n.links.index == f"{ct} renewable oil -> EU oil"]
 
         lhs.append(
             (
@@ -459,8 +460,12 @@ def add_co2limit_country(n, limit_countries, snakemake):
             ).sum()
         )
 
-        incoming_methanol = n.links.index[n.links.index == "EU methanol -> DE methanol"]
-        outgoing_methanol = n.links.index[n.links.index == "DE methanol -> EU methanol"]
+        incoming_methanol = n.links.index[
+            n.links.index == f"EU methanol -> {ct} methanol"
+        ]
+        outgoing_methanol = n.links.index[
+            n.links.index == f"{ct} methanol -> EU methanol"
+        ]
 
         lhs.append(
             (
@@ -480,8 +485,8 @@ def add_co2limit_country(n, limit_countries, snakemake):
         )
 
         # Methane
-        incoming_CH4 = n.links.index[n.links.index == "EU renewable gas -> DE gas"]
-        outgoing_CH4 = n.links.index[n.links.index == "DE renewable gas -> EU gas"]
+        incoming_CH4 = n.links.index[n.links.index == f"EU renewable gas -> {ct} gas"]
+        outgoing_CH4 = n.links.index[n.links.index == f"{ct} renewable gas -> EU gas"]
 
         lhs.append(
             (
@@ -754,11 +759,11 @@ def additional_functionality(n, snapshots, snakemake):
     force_boiler_profiles_existing_per_boiler(n)
 
     if isinstance(constraints["co2_budget_national"], dict):
-        limit_countries = constraints["co2_budget_national"][investment_year]
-        add_co2limit_country(
+        add_national_co2_budgets(
             n,
-            limit_countries,
             snakemake,
+            constraints["co2_budget_national"],
+            investment_year,
         )
     else:
         logger.warning("No national CO2 budget specified!")

--- a/scripts/pypsa-de/additional_functionality.py
+++ b/scripts/pypsa-de/additional_functionality.py
@@ -382,7 +382,7 @@ def add_national_co2_budgets(n, snakemake, national_co2_budgets, investment_year
     for ct in national_co2_budgets:
         if ct != "DE":
             logger.error(
-                f"CO2 budget for countries other than `DE` is not yet implemented. Found country {ct}. Please check the config file."
+                f"CO2 budget for countries other than `DE` is not yet supported. Found country {ct}. Please check the config file."
             )
 
         limit = co2_total_totals[ct] * national_co2_budgets[ct][investment_year]

--- a/scripts/pypsa-de/additional_functionality.py
+++ b/scripts/pypsa-de/additional_functionality.py
@@ -380,6 +380,11 @@ def add_national_co2_budgets(n, snakemake, national_co2_budgets, investment_year
     co2_total_totals = co2_totals[sectors].sum(axis=1) * nyears
 
     for ct in national_co2_budgets:
+        if ct != "DE":
+            logger.error(
+                f"CO2 budget for countries other than `DE` is not yet implemented. Found country {ct}. Please check the config file."
+            )
+        
         limit = co2_total_totals[ct] * national_co2_budgets[ct][investment_year]
         logger.info(
             f"Limiting emissions in country {ct} to {national_co2_budgets[ct][investment_year]:.1%} of "

--- a/scripts/pypsa-de/additional_functionality.py
+++ b/scripts/pypsa-de/additional_functionality.py
@@ -384,7 +384,7 @@ def add_national_co2_budgets(n, snakemake, national_co2_budgets, investment_year
             logger.error(
                 f"CO2 budget for countries other than `DE` is not yet implemented. Found country {ct}. Please check the config file."
             )
-        
+
         limit = co2_total_totals[ct] * national_co2_budgets[ct][investment_year]
         logger.info(
             f"Limiting emissions in country {ct} to {national_co2_budgets[ct][investment_year]:.1%} of "

--- a/scripts/pypsa-de/build_scenarios.py
+++ b/scripts/pypsa-de/build_scenarios.py
@@ -135,7 +135,11 @@ def write_to_scenario_yaml(input, output, scenarios, df):
     file_path = Path(input)
     config = yaml.load(file_path)
     for scenario in scenarios:
-        reference_scenario = config[scenario]["iiasa_database"]["reference_scenario"]
+        reference_scenario = (
+            config[scenario]
+            .get("iiasa_database", {})
+            .get("reference_scenario", "KN2045_Mix")
+        )
 
         planning_horizons = [
             2020,
@@ -165,7 +169,11 @@ def write_to_scenario_yaml(input, output, scenarios, df):
         if not config[scenario].get("sector"):
             config[scenario]["sector"] = {}
 
-        config[scenario]["sector"]["aviation_demand_factor"] = {}
+        if config[scenario]["sector"].get("aviation_demand_factor") is not None:
+            logger.warning(f"Overwriting aviation_demand_factor in {scenario} scenario")
+        else:
+            config[scenario]["sector"]["aviation_demand_factor"] = {}
+
         for year in planning_horizons:
             config[scenario]["sector"]["aviation_demand_factor"][year] = round(
                 aviation_demand_factor.loc[year].item(), 4
@@ -178,18 +186,40 @@ def write_to_scenario_yaml(input, output, scenarios, df):
         dri_fraction = get_DRI_share(
             df.loc[:, reference_scenario, :], planning_horizons
         )
+        if not config[scenario].get("industry"):
+            config[scenario]["industry"] = {}
 
-        config[scenario]["industry"]["St_primary_fraction"] = {}
-        config[scenario]["industry"]["DRI_fraction"] = {}
+        if config[scenario]["industry"].get("St_primary_fraction") is not None:
+            logger.warning(f"Overwriting St_primary_fraction in {scenario} scenario")
+        else:
+            config[scenario]["industry"]["St_primary_fraction"] = {}
+
         for year in st_primary_fraction.columns:
             config[scenario]["industry"]["St_primary_fraction"][year] = round(
                 st_primary_fraction.loc["Primary_Steel_Share", year].item(), 4
             )
+
+        if config[scenario]["industry"].get("DRI_fraction") is not None:
+            logger.warning(f"Overwriting DRI_fraction in {scenario} scenario")
+        else:
+            config[scenario]["industry"]["DRI_fraction"] = {}
+
+        for year in dri_fraction.columns:
             config[scenario]["industry"]["DRI_fraction"][year] = round(
                 dri_fraction.loc["DRI_Steel_Share", year].item(), 4
             )
+        if not config[scenario].get("solving"):
+            config[scenario]["solving"] = {}
+        if not config[scenario]["solving"].get("constraints"):
+            config[scenario]["solving"]["constraints"] = {}
+        if (
+            config[scenario]["solving"]["constraints"].get("co2_budget_national")
+            is not None
+        ):
+            logger.warning(f"Overwriting co2_budget_national in {scenario} scenario")
+        else:
+            config[scenario]["solving"]["constraints"]["co2_budget_national"] = {}
 
-        config[scenario]["solving"]["constraints"]["co2_budget_national"] = {}
         for year, target in co2_budget_fractions.items():
             config[scenario]["solving"]["constraints"]["co2_budget_national"][year] = {}
             config[scenario]["solving"]["constraints"]["co2_budget_national"][year][

--- a/scripts/pypsa-de/build_scenarios.py
+++ b/scripts/pypsa-de/build_scenarios.py
@@ -171,24 +171,23 @@ def write_to_scenario_yaml(input, output, scenarios, df):
                 aviation_demand_factor.loc[year].item(), 4
             )
 
-        if not snakemake.params.db_name == "ariadne":
-            st_primary_fraction = get_primary_steel_share(
-                df.loc[:, reference_scenario, :], planning_horizons
-            )
+        st_primary_fraction = get_primary_steel_share(
+            df.loc[:, reference_scenario, :], planning_horizons
+        )
 
-            dri_fraction = get_DRI_share(
-                df.loc[:, reference_scenario, :], planning_horizons
-            )
+        dri_fraction = get_DRI_share(
+            df.loc[:, reference_scenario, :], planning_horizons
+        )
 
-            config[scenario]["industry"]["St_primary_fraction"] = {}
-            config[scenario]["industry"]["DRI_fraction"] = {}
-            for year in st_primary_fraction.columns:
-                config[scenario]["industry"]["St_primary_fraction"][year] = round(
-                    st_primary_fraction.loc["Primary_Steel_Share", year].item(), 4
-                )
-                config[scenario]["industry"]["DRI_fraction"][year] = round(
-                    dri_fraction.loc["DRI_Steel_Share", year].item(), 4
-                )
+        config[scenario]["industry"]["St_primary_fraction"] = {}
+        config[scenario]["industry"]["DRI_fraction"] = {}
+        for year in st_primary_fraction.columns:
+            config[scenario]["industry"]["St_primary_fraction"][year] = round(
+                st_primary_fraction.loc["Primary_Steel_Share", year].item(), 4
+            )
+            config[scenario]["industry"]["DRI_fraction"][year] = round(
+                dri_fraction.loc["DRI_Steel_Share", year].item(), 4
+            )
 
         config[scenario]["solving"]["constraints"]["co2_budget_national"] = {}
         for year, target in co2_budget_fractions.items():

--- a/scripts/pypsa-de/export_ariadne_variables.py
+++ b/scripts/pypsa-de/export_ariadne_variables.py
@@ -1239,7 +1239,6 @@ def get_primary_energy(n, region):
             **kwargs,
         )
         .get(("Link", "DE gas compressing"), pd.Series(0))
-        .round()
         .item()
     )
 

--- a/scripts/pypsa-de/plot_ariadne_scenario_comparison.py
+++ b/scripts/pypsa-de/plot_ariadne_scenario_comparison.py
@@ -1,5 +1,8 @@
 import os
 
+import matplotlib
+
+matplotlib.use("Agg")  # Use a non-interactive backend
 import matplotlib.pyplot as plt
 import pandas as pd
 
@@ -12,10 +15,10 @@ def scenario_plot(df, var):
         unit = "billion EUR2020/yr"
     df = df.droplevel("Unit")
     ax = df.T.plot(xlabel="years", ylabel=str(unit), title=str(var))
-    plt.close()
     prefix = snakemake.config["run"]["prefix"]
     var = var.replace("|", "-").replace("\\", "-").replace(" ", "-").replace("/", "-")
     ax.figure.savefig(f"results/{prefix}/ariadne_comparison/{var}", bbox_inches="tight")
+    plt.close(ax.figure)
 
 
 if __name__ == "__main__":
@@ -46,5 +49,3 @@ if __name__ == "__main__":
 
     for var in df._get_label_or_level_values("Variable"):
         scenario_plot(df.xs(var, level="Variable"), var)
-
-    var = "Price|Carbon"


### PR DESCRIPTION
This PR:

- Makes `Mix` the default scenario and changes pypsa.de.yaml accordingly
- Simplifies the definition of existing scenarios, only the delta to `Mix` has to be specified explicitly
- Makes scenario building more robust, e.g. an empty scenario defintion will now simply run the default config
- Changes the syntax of the national_co2_budget configuration to comply with that of other constraints


Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
