### PR TITLE
Warn the user if the scenario.automated.yaml is outdated or non existent

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -78,6 +78,19 @@ if config["foresight"] == "perfect":
 
     include: "rules/solve_perfect.smk"
 
+# Pypsa-DE requires the scenario management by default
+onstart:
+    scenarios_file=Path(config["run"]["scenarios"]["file"])
+    manual_file=Path(config["run"]["scenarios"]["manual_file"])
+
+    if not scenarios_file.exists():
+        print(f"\033[91mWARNING: {scenarios_file} does not exist. Please run `snakemake build_scenarios` to create it.\033[0m")
+    elif manual_file.exists():
+        if scenarios_file.stat().st_mtime < manual_file.stat().st_mtime:
+            print(f"\033[91mWARNING: {manual_file} is newer than {scenarios_file}. Please run `snakemake build_scenarios` to update {scenarios_file}.\033[0m")
+    else:
+        print(f"\033[91mWARNING: {manual_file} does not exist. Please create it to use the scenario management.\033[0m")
+    print(f"Scenario file {scenarios_file} exists and is up to date. Starting workflow.")
 
 rule all:
     input:
@@ -147,15 +160,6 @@ rule all:
             ),
         ),
     default_target: True
-
-
-rule create_scenarios:
-    output:
-        config["run"]["scenarios"]["file"],
-    conda:
-        "envs/environment.yaml"
-    script:
-        "config/create_scenarios.py"
 
 
 rule purge:

--- a/Snakefile
+++ b/Snakefile
@@ -78,19 +78,29 @@ if config["foresight"] == "perfect":
 
     include: "rules/solve_perfect.smk"
 
+
 # Pypsa-DE requires the scenario management by default
 onstart:
-    scenarios_file=Path(config["run"]["scenarios"]["file"])
-    manual_file=Path(config["run"]["scenarios"]["manual_file"])
+    scenarios_file = Path(config["run"]["scenarios"]["file"])
+    manual_file = Path(config["run"]["scenarios"]["manual_file"])
 
     if not scenarios_file.exists():
-        print(f"\033[91mWARNING: {scenarios_file} does not exist. Please run `snakemake build_scenarios` to create it.\033[0m")
+        print(
+            f"\033[91mWARNING: {scenarios_file} does not exist. Please run `snakemake build_scenarios` to create it.\033[0m"
+        )
     elif manual_file.exists():
         if scenarios_file.stat().st_mtime < manual_file.stat().st_mtime:
-            print(f"\033[91mWARNING: {manual_file} is newer than {scenarios_file}. Please run `snakemake build_scenarios` to update {scenarios_file}.\033[0m")
+            print(
+                f"\033[91mWARNING: {manual_file} is newer than {scenarios_file}. Please run `snakemake build_scenarios` to update {scenarios_file}.\033[0m"
+            )
     else:
-        print(f"\033[91mWARNING: {manual_file} does not exist. Please create it to use the scenario management.\033[0m")
-    print(f"Scenario file {scenarios_file} exists and is up to date. Starting workflow.")
+        print(
+            f"\033[91mWARNING: {manual_file} does not exist. Please create it to use the scenario management.\033[0m"
+        )
+    print(
+        f"Scenario file {scenarios_file} exists and is up to date. Starting workflow."
+    )
+
 
 rule all:
     input:


### PR DESCRIPTION
The goal of this PR is to warn the user about some errors that might occur when using the scenario management in pypsa-de incorrectly

Ideally the workflow wouldn't just print a warning, but fail  but i did not find out how to do that yet (because it should only fail when `ariadne_all` is called and not when `build_scenarios` is called)

Even more ideally, build_scenarios would be included in the default workflow, but that seems even more complicated to achieve as that means modifying the snakemake config in runtime.

Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
