### PR TITLE
Fix foreign investments according to reference network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+- Provide option to fix foreign investments outside Germany to optimized capacities of reference scenario
 - Simplified scenarion definition and made `Mix` the default scenario
 - 0.3: workflow is all public now, no longer requires credentials to internal data
 - Allowing myopic optimization until 2050

--- a/Snakefile
+++ b/Snakefile
@@ -371,12 +371,12 @@ rule modify_district_heat_share:
 
 
 def get_reference_network(w):
-    ref_scenario = config["run"]["scenarios"]["reference"]
+    ref_scenario = config["run"]["scenarios"]["fix_foreign_investments"]["reference_scenario"]
     if (
-        config["run"]["scenarios"]["fix_foreign_reference_investments"]
+        config_provider("run", "scenarios", "fix_foreign_investments", "enable")
         and w.run != ref_scenario
     ):
-        return f"results/{config['run']['prefix']}/{ref_scenario}/networks/base_s_{w.clusters}_{w.opts}_{w.sector_opts}_{w.planning_horizons}.nc"
+        return f"results/{config["run"]["prefix"]}/{ref_scenario}/networks/base_s_{w.clusters}_{w.opts}_{w.sector_opts}_{w.planning_horizons}.nc"
     else:
         return []
 
@@ -414,10 +414,10 @@ rule modify_prenetwork:
         shipping_methanol_share=config_provider("sector", "shipping_methanol_share"),
         mwh_meoh_per_tco2=config_provider("sector", "MWh_MeOH_per_tCO2"),
         scale_capacity=config_provider("scale_capacity"),
-        fix_foreign_reference_investments=config_provider(
-            "run", "scenarios", "fix_foreign_reference_investments"
+        fix_foreign_investments=config_provider(
+            "run", "scenarios", "fix_foreign_investments"
         ),
-        reference_scenario=config_provider("run", "scenarios", "reference"),
+        reference_scenario=config_provider("run", "scenarios", "fix_foreign_investments", "reference_scenario"),
     input:
         costs_modifications="ariadne-data/costs_{planning_horizons}-modifications.csv",
         network=resources(

--- a/Snakefile
+++ b/Snakefile
@@ -370,6 +370,16 @@ rule modify_district_heat_share:
         "scripts/pypsa-de/modify_district_heat_share.py"
 
 
+def get_reference_network(w):
+    ref_scenario = config["run"]["scenarios"]["reference"]
+    if (
+        config["run"]["scenarios"]["fix_foreign_reference_investments"]
+        and w.run != ref_scenario
+    ):
+        return f"results/{config['run']['prefix']}/{ref_scenario}/networks/base_s_{w.clusters}_{w.opts}_{w.sector_opts}_{w.planning_horizons}.nc"
+    else:
+        return []
+
 rule modify_prenetwork:
     params:
         efuel_export_ban=config_provider("solving", "constraints", "efuel_export_ban"),
@@ -404,6 +414,10 @@ rule modify_prenetwork:
         shipping_methanol_share=config_provider("sector", "shipping_methanol_share"),
         mwh_meoh_per_tco2=config_provider("sector", "MWh_MeOH_per_tCO2"),
         scale_capacity=config_provider("scale_capacity"),
+        fix_foreign_reference_investments=config_provider(
+            "run", "scenarios", "fix_foreign_reference_investments"
+        ),
+        reference_scenario=config_provider("run", "scenarios", "reference"),
     input:
         costs_modifications="ariadne-data/costs_{planning_horizons}-modifications.csv",
         network=resources(
@@ -432,6 +446,7 @@ rule modify_prenetwork:
         regions_onshore=resources("regions_onshore_base_s_{clusters}.geojson"),
         regions_offshore=resources("regions_offshore_base_s_{clusters}.geojson"),
         offshore_connection_points="ariadne-data/offshore_connection_points.csv",
+        reference_network=get_reference_network,
     output:
         network=resources(
             "networks/base_s_{clusters}_{opts}_{sector_opts}_{planning_horizons}_final.nc"

--- a/config/config.de.yaml
+++ b/config/config.de.yaml
@@ -16,6 +16,8 @@ run:
     enable: true
     manual_file: config/scenarios.manual.yaml
     file: config/scenarios.automated.yaml
+    reference: KN2045_Mix
+    fix_foreign_reference_investments: false
   shared_resources:
     policy: base #stops recalculating
     exclude:

--- a/config/config.de.yaml
+++ b/config/config.de.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20250507_simple_scenarios
+  prefix: 20250522_fix_neighbours
   name:
   # - ExPol
   - KN2045_Mix
@@ -16,8 +16,9 @@ run:
     enable: true
     manual_file: config/scenarios.manual.yaml
     file: config/scenarios.automated.yaml
-    reference: KN2045_Mix
-    fix_foreign_reference_investments: false
+    fix_foreign_investments:
+      enable: false
+      reference_scenario: KN2045_Mix
   shared_resources:
     policy: base #stops recalculating
     exclude:

--- a/scripts/pypsa-de/modify_prenetwork.py
+++ b/scripts/pypsa-de/modify_prenetwork.py
@@ -1265,7 +1265,7 @@ def scale_capacity(n, scaling):
                 ]
 
 
-def fix_foreign_reference_investments(n, n_ref):
+def fix_foreign_investments(n, n_ref):
     """
     For all extendable components located outside Germany, this function sets their
     minimum and maximum capacity limits to match the optimized capacity from a
@@ -1308,12 +1308,12 @@ def fix_foreign_reference_investments(n, n_ref):
             # For lines, and links, check both buses
             non_german = (
                 component.filter(regex="bus[012]")
-                .apply(lambda x: ~x.str.startswith("DE"), axis=1)
+                .apply(lambda x: ~x.str.startswith(("DE", "EU")), axis=1)
                 .any(axis=1)
             )
         else:
             # For other components, check if bus is not in Germany
-            non_german = ~component.bus.str.startswith("DE")
+            non_german = ~component.bus.str.startswith(("DE", "EU"))
 
         # Only fix extendable components
         extendable = (
@@ -1332,28 +1332,29 @@ def fix_foreign_reference_investments(n, n_ref):
 
         indices = component.index[to_fix]
 
-        # Copy the optimized capacity from baseline to fixed capacity
+        # Copy the optimized capacity from baseline to fixed capacity rounding values
+        # to the nearest integer to avoid constraint violations
         if c == "Store":
             n.stores.loc[indices, "e_nom_min"] = baseline_component.loc[
                 indices, "e_nom_opt"
-            ]
+            ].apply(np.floor)
             n.stores.loc[indices, "e_nom_max"] = baseline_component.loc[
                 indices, "e_nom_opt"
-            ]
+            ].apply(np.ceil)
         elif c == "Line":
             n.lines.loc[indices, "s_nom_min"] = baseline_component.loc[
                 indices, "s_nom_opt"
-            ]
+            ].apply(np.floor)
             n.lines.loc[indices, "s_nom_max"] = baseline_component.loc[
                 indices, "s_nom_opt"
-            ]
+            ].apply(np.ceil)
         else:
             n.df(c).loc[indices, "p_nom_min"] = baseline_component.loc[
                 indices, "p_nom_opt"
-            ]
+            ].apply(np.floor)
             n.df(c).loc[indices, "p_nom_max"] = baseline_component.loc[
                 indices, "p_nom_opt"
-            ]
+            ].apply(np.ceil)
 
         logger.info(f"Fixed {sum(to_fix)} {c} components outside Germany")
 
@@ -1441,13 +1442,13 @@ if __name__ == "__main__":
     sanitize_custom_columns(n)
 
     if (
-        snakemake.params["fix_foreign_reference_investments"]
+        snakemake.params["fix_foreign_investments"]
         and snakemake.wildcards.run != snakemake.params["reference_scenario"]
     ):
         logger.info(
             "Fixing investments for components outside Germany based on the reference scenario."
         )
         n_ref = pypsa.Network(snakemake.input.reference_network)
-        fix_foreign_reference_investments(n, n_ref)
+        fix_foreign_investments(n, n_ref)
 
     n.export_to_netcdf(snakemake.output.network)

--- a/scripts/pypsa-de/modify_prenetwork.py
+++ b/scripts/pypsa-de/modify_prenetwork.py
@@ -1267,7 +1267,29 @@ def scale_capacity(n, scaling):
 
 def fix_foreign_reference_investments(n, n_ref):
     """
-    Fix reference investments for non-DE components.
+    For all extendable components located outside Germany, this function sets their
+    minimum and maximum capacity limits to match the optimized capacity from a
+    reference network. This effectively fixes the investment decisions for these
+    components to their reference values.
+
+    Components are identified as non-German based on their bus location:
+    - For Line and Link: any connected bus is outside Germany
+    - For other components: the primary bus is outside Germany
+
+    Only components with extendable capacity are modified (those with
+    [p|s|e]_nom_extendable set to True).
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        Network object to modify
+    n_ref : pypsa.Network
+        Reference network object containing optimized capacity values
+
+    Returns
+    -------
+    None
+        Network is modified in-place with updated capacity limits
     """
     # List of component types that can have investment decisions
     investment_components = ["Generator", "StorageUnit", "Store", "Link", "Line"]


### PR DESCRIPTION
This PR allows users to fix investments in non-German EU countries to the optimal values of a reference scenario in a multi-scenario model setup. This is achieved by sequentially optimizing the reference scenario first, followed by all other scenarios.

The feature is enabled by setting the config parameter `run:scenarios:fix_foreign_investments:enable` to `true` (default is `false`). The reference scenario must be one of the entries in the list defined under `run:name` and is selected using the parameter `run:scenarios:fix_foreign_investments:reference_scenario`.

Investments are fixed in the `fix_foreign_investments` function within the `modify_prenetwork` script for all components that do not involve any buses located in Germany or outside the EU. This is done by setting the lower and upper bounds of the capacity constraints (i.e. `p_nom_min`/`p_nom_max` for generators, links, and storage units; `s_nom_min`/`s_nom_max` for lines; and `e_nom_min`/`e_nom_max` for stores) to the same value (besides deviations from floor/ceil rounding operations): the optimal capacity (`p_nom_opt`, `s_nom_opt`, or `e_nom_opt`) obtained from the optimization of the reference network.

To account for minor numerical inaccuracies in the reference solution due to solver feasibility tolerances, floor values are used for the minimum capacity constraints and ceiling values for the maximum capacity constraints.

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
