### PR TITLE
use mobility demand from uba projektionsbericht

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -367,10 +367,14 @@ rule build_mobility_demand:
         reference_scenario=config_provider("iiasa_database", "reference_scenario"),
         planning_horizons=config_provider("scenario", "planning_horizons"),
         leitmodelle=config_provider("iiasa_database", "leitmodelle"),
-        ageb_for_transport=config_provider("iiasa_database", "ageb_for_transport"),
+        uba_for_mobility=config_provider("iiasa_database", "uba_for_mobility"),
+        shipping_oil_share=config_provider("sector", "shipping_oil_share"),
+        aviation_demand_factor=config_provider("sector", "aviation_demand_factor"),
+        energy_totals_year=config_provider("energy", "energy_totals_year"),
     input:
         ariadne="resources/ariadne_database.csv",
         clustered_pop_layout=resources("pop_layout_base_s_{clusters}.csv"),
+        energy_totals=resources("energy_totals.csv"),
     output:
         mobility_demand=resources(
             "mobility_demand_aladin_{clusters}_{planning_horizons}.csv"

--- a/config/config.de.yaml
+++ b/config/config.de.yaml
@@ -43,7 +43,7 @@ iiasa_database:
   - KN2045_NFhoch
   reference_scenario: KN2045_Mix
   region: Deutschland
-  ageb_for_transport: true
+  uba_for_mobility: true # MWMS scenario from Projektionsbericht 2025
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#foresight
 foresight: myopic


### PR DESCRIPTION
This will add a new option to the transport sector by defining a mobility demand from the UBA Projektoinsbericht:

https://www.umweltbundesamt.de/sites/default/files/medien/11850/publikationen/projektionsbericht_2025.pdf

Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
