### PR TITLE
fix: update Zensus 2022 heating type data source URL

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -410,7 +410,7 @@ rule prepare_district_heating_subnodes:
         cities="data/fernwaermeatlas/cities_geolocations.geojson",
         lau_regions="data/lau_regions.zip",
         census=storage(
-            "https://www.zensus2022.de/static/Zensus_Veroeffentlichung/Zensus2022_Heizungsart.zip",
+            "https://www.destatis.de/static/DE/zensus/gitterdaten/Zensus2022_Heizungsart.zip",
             keep_local=True,
         ),
         osm_land_cover=storage(


### PR DESCRIPTION
The census data used for synthesizing district heating areas has migrated to the Destatis domain, breaking the existing URL in the model. This PR updates the URL accordingly.