### PR TITLE
add weather year config option to build_scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+- Added a helper function to change the weather_year to build_scenario
 - Longer lifetime (40 years) is only applied to existing gas CHPs, not new ones. Added a new config entry `existing_capacities:fill_value_gas_chp_lifetime`
 - Bugfix: gas CHPs are extendable again
 - Simplified scenarion definition and made `Mix` the default scenario

--- a/config/config.de.yaml
+++ b/config/config.de.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20253006_fix_chp_lifetime
+  prefix: 20250721_weather_year_helper
   name:
   # - ExPol
   - KN2045_Mix

--- a/scripts/pypsa-de/build_scenarios.py
+++ b/scripts/pypsa-de/build_scenarios.py
@@ -129,6 +129,47 @@ def get_co2_budget(df, source):
     return target_fractions_pypsa.round(3)
 
 
+def write_weather_dependent_config(config, scenario, weather_year):
+    # Insert weather-dependent configuration dynamically
+    cutout_name = f"europe-{weather_year}-sarah3-era5"
+
+    # atlite section
+    config[scenario]["atlite"] = {
+        "default_cutout": cutout_name,
+        "cutouts": {
+            cutout_name: {
+                "module": ["sarah", "era5"],
+                "x": [-12.0, 42.0],
+                "y": [33.0, 72.0],
+                "dx": 0.3,
+                "dy": 0.3,
+                "time": [str(weather_year), str(weather_year)],
+            }
+        },
+    }
+
+    # snapshots section
+    config[scenario]["snapshots"] = {
+        "start": f"{weather_year}-01-01",
+        "end": f"{int(weather_year) + 1}-01-01",
+        "inclusive": "left",
+    }
+
+    # renewable section
+    config[scenario]["renewable"] = {
+        "onwind": {"cutout": cutout_name},
+        "offwind-ac": {"cutout": cutout_name},
+        "offwind-dc": {"cutout": cutout_name},
+        "offwind-float": {"cutout": cutout_name},
+        "solar": {"cutout": cutout_name},
+        "solar-hsat": {"cutout": cutout_name},
+        "hydro": {"cutout": cutout_name},
+    }
+
+    # lines section
+    config[scenario]["lines"] = {"dynamic_line_rating": {"cutout": cutout_name}}
+
+
 def write_to_scenario_yaml(input, output, scenarios, df):
     # read in yaml file
     yaml = ruamel.yaml.YAML()
@@ -140,6 +181,13 @@ def write_to_scenario_yaml(input, output, scenarios, df):
                 f"Found an empty scenario config for {scenario}. Using default config `pypsa.de.yaml`."
             )
             config[scenario] = {}
+        if config[scenario].get("weather_year", False):
+            if snakemake.config["run"]["shared_resources"]["policy"] != False:
+                logger.warning(
+                    "If you are running scenarios with multiple weather years, make sure to deactivate shared_resources!"
+                )
+            weather_year = config[scenario]["weather_year"]
+            write_weather_dependent_config(config, scenario, weather_year)
 
         reference_scenario = (
             config[scenario]

--- a/scripts/pypsa-de/build_scenarios.py
+++ b/scripts/pypsa-de/build_scenarios.py
@@ -182,11 +182,15 @@ def write_to_scenario_yaml(input, output, scenarios, df):
             )
             config[scenario] = {}
         if config[scenario].get("weather_year", False):
-            if snakemake.config["run"]["shared_resources"]["policy"] != False:
-                logger.warning(
-                    "If you are running scenarios with multiple weather years, make sure to deactivate shared_resources!"
-                )
             weather_year = config[scenario]["weather_year"]
+            default_weather_year = int(snakemake.config["snapshots"]["start"][:4])
+            if (
+                snakemake.config["run"]["shared_resources"]["policy"] != False
+                and weather_year != default_weather_year
+            ):
+                raise ValueError(
+                    f"The run uses shared resources, but weather year {weather_year} in scenario {scenario} does not match the start year of the snapshots {default_weather_year}. If you are running scenarios with multiple weather years, make sure to deactivate shared_resources!"
+                )
             write_weather_dependent_config(config, scenario, weather_year)
 
         reference_scenario = (


### PR DESCRIPTION
This PR introduces a helper function to change the weather_year in build_scenarios.

The new config `weather_year` is only read by the build_scenarios sub-workflow

Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
