### PR TITLE
ci: run model tests weekly only

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,6 @@ on:
     branches:
     - main
   schedule:
-  - cron: "0 5 * * 1-6"
   - cron: "0 5 * * 0"
   workflow_dispatch:
 


### PR DESCRIPTION
As discussed with @lindnemi, most data retrievals are already tested within daily eur runs