### PR TITLE
Bug fix: Capacity limit subsetting in additional functionality

### DIFF
--- a/scripts/pypsa-de/additional_functionality.py
+++ b/scripts/pypsa-de/additional_functionality.py
@@ -37,7 +37,7 @@ def add_capacity_limits(n, investment_year, limits_capacity, sense="maximum"):
                     valid_components & ~c.static[attr + "_nom_extendable"]
                 ]
                 extendable_index = c.static.index[
-                    valid_components & c.static[attr + "_nom_extendable"]
+                    valid_components & c.static[attr + "_nom_extendable"] & c.static.active
                 ]
 
                 existing_capacity = c.static.loc[existing_index, attr + "_nom"].sum()


### PR DESCRIPTION
**Proposed changes**
- Adding `c.static.active` check for adding capacity limits. Otherwise workflow will break depending on the scenario and configuration.
- `extendable_index = c.static.index[valid_components & c.static[attr + "_nom_extendable"] & c.static.active]`

Before asking for a review for this PR make sure to complete the following checklist:

- [X] Workflow with target rule `ariadne_all` completes without errors
- [X] The latest `main` has been merged into the PR
