### PR TITLE
Restricting network topology to interconnectors only

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -412,9 +412,13 @@ def create_network_topology(
     lk_attrs = n.links.columns.intersection(lk_attrs)
 
     candidates = pd.concat(
-        [n.lines[ln_attrs],
-         n.links.loc[(n.links.carrier.isin(carriers)) & (n.links.underwater_fraction > 0.1),
-         lk_attrs]]
+        [
+            n.lines[ln_attrs],
+            n.links.loc[
+                (n.links.carrier.isin(carriers)) & (n.links.underwater_fraction > 0.1),
+                lk_attrs,
+            ],
+        ]
     ).fillna(0)
 
     # base network topology purely on location not carrier

--- a/scripts/pypsa-de/additional_functionality.py
+++ b/scripts/pypsa-de/additional_functionality.py
@@ -37,7 +37,9 @@ def add_capacity_limits(n, investment_year, limits_capacity, sense="maximum"):
                     valid_components & ~c.static[attr + "_nom_extendable"]
                 ]
                 extendable_index = c.static.index[
-                    valid_components & c.static[attr + "_nom_extendable"] & c.static.active
+                    valid_components
+                    & c.static[attr + "_nom_extendable"]
+                    & c.static.active
                 ]
 
                 existing_capacity = c.static.loc[existing_index, attr + "_nom"].sum()


### PR DESCRIPTION
closes https://github.com/PyPSA/pypsa-de/issues/138

`create_network_topology` is slightly adjusted and excludes DC links that have a underwaterfraction smaller than 0.1.
This ensures that only interconnector links are used as a network topology for CO2 and H2 pipelines.
The biomass transport is now restricted to bus regions that are next to each other excluding any interconnector transport links.

Before asking for a review for this PR make sure to complete the following checklist:

- [x] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
_not applicable_
- [x] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
_not applicable_
- [x] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
_not applicable_


### Before
<img width="94.2" height="98.3" alt="image" src="https://github.com/user-attachments/assets/e859408d-4297-4ce9-94ae-66dfa07c4870" />

### After
<img width="94.2" height="98.3" alt="image" src="https://github.com/user-attachments/assets/1f30101b-9380-46ae-a004-fd87eab29340" />
