### PR TITLE
restrict rule 'build_existing_chp_de' memory for reliable PyPSA-AT testruns

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -670,6 +670,8 @@ rule build_existing_chp_de:
         ),
     output:
         german_chp=resources("german_chp_base_s_{clusters}.csv"),
+    resources:
+        mem_mb=4000,
     log:
         logs("build_existing_chp_de_{clusters}.log"),
     script:


### PR DESCRIPTION
Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [x] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`

A minor change to prevent [PyPSA-AT CI tests](https://github.com/AGGM-AG/pypsa-at/blob/main/.github/workflows/test-pixi.yaml) from failing with `<Signals.SIGTERM: 15>` (=out of memory) in rule `build_existing_chp_de`. Here is an example for a [failed testrun due to memory problems](https://github.com/AGGM-AG/pypsa-at/actions/runs/19295344784/job/55175836571). Setting a resource limit for `build_existing_chp_de` fixes the issue. 

Sorry, I did not run the full PyPSA-DE workflow. If you require more checked boxes, let me know and I'll see to it in the next couple of days.  